### PR TITLE
[codex] Fix review findings in predictions flows

### DIFF
--- a/functions/reminders/sendReminder.js
+++ b/functions/reminders/sendReminder.js
@@ -6,7 +6,7 @@ import {getApps, initializeApp} from "firebase-admin/app";
 import express from "express";
 import {onRequest} from "firebase-functions/v2/https";
 
-if (!getApps()) {
+if (!getApps().length) {
     initializeApp();
 }
 
@@ -60,7 +60,7 @@ app.post("/", async (req, res) => {
                                 [
                                     {
                                         text: "Сделать прогноз ⚽",
-                                        web_app: { url: 'https://predictions-bot.netlify.app/predict?startapp=match_${matchId}' }
+                                        web_app: { url: `https://predictions-bot.netlify.app/predict?startapp=match_${matchId}` }
                                     }
                                 ]
                             ]

--- a/src/components/StandingsTable.jsx
+++ b/src/components/StandingsTable.jsx
@@ -3,12 +3,16 @@ import "./StandingsTable.css"
 import { motion, AnimatePresence } from "framer-motion";
 import {calculatePoints} from "../../functions/scoreService.js";
 import {useMatches} from "../hooks/useMatches.js";
-import {usePredictions} from "../hooks/usePredictions.js";
-import {getAllPredictions} from "../services/getPredictionsForMatch.js";
+
+function getMatchStartMs(match) {
+    if (match.date instanceof Date) return match.date.getTime();
+    if (match.date?.seconds) return match.date.seconds * 1000;
+    return 0;
+}
 
 const getModifiedStandings = (standings, matches, predictions) => {
     const now = Date.now();
-    const liveMatches = matches.filter(match => match.date <= now && !match.isFinished);
+    const liveMatches = matches.filter((match) => getMatchStartMs(match) <= now && !match.isFinished);
     const extraPoints = {};
 
     liveMatches.forEach(match => {
@@ -32,7 +36,7 @@ const getModifiedStandings = (standings, matches, predictions) => {
 const StandingsTable = ({ league, standings, roundPoints, onBack, predictions }) => {
     const [selectedRound, setSelectedRound] = useState(0);
     const [liveEnabled, setLiveEnabled] = useState(false);
-    const { matches, loading } = useMatches();
+    const { matches } = useMatches();
 
     const modifiedStandings = useMemo(() => {
         if (selectedRound !== 0) {

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -12,6 +12,7 @@ import {
 } from "firebase/firestore";
 
 const db = getFirestore();
+const CURRENT_SEASON_ID = "2025-26";
 
 function toNumberId(userId) {
     const numericId = Number(userId);
@@ -31,6 +32,7 @@ export default function UserProfile() {
             const standingsQuery = query(
                 collection(db, "standings"),
                 where("leagueId", "==", "epl"),
+                where("seasonId", "==", CURRENT_SEASON_ID),
                 where("userId", "==", normalizedUserId)
             );
 
@@ -47,6 +49,7 @@ export default function UserProfile() {
             const q = query(
                 collection(db, "roundPoints"),
                 where("userId", "==", normalizedUserId),
+                where("seasonId", "==", CURRENT_SEASON_ID),
                 where("leagueId", "==", "epl")
             );
 

--- a/src/components/UserProfile/UserProfile.jsx
+++ b/src/components/UserProfile/UserProfile.jsx
@@ -1,87 +1,146 @@
-import React from "react";
+import React, {useEffect, useState} from "react";
 import "./UserProfile.css";
 import {Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis} from "recharts";
 import {useParams} from "react-router-dom";
-import {useEffect, useState} from "react";
-import {getDoc, doc, getFirestore, query, collection, where, getDocs} from "firebase/firestore";
+import {
+    collection,
+    documentId,
+    getDocs,
+    getFirestore,
+    query,
+    where
+} from "firebase/firestore";
 
 const db = getFirestore();
 
+function toNumberId(userId) {
+    const numericId = Number(userId);
+    return Number.isNaN(numericId) ? userId : numericId;
+}
+
 export default function UserProfile() {
     const { userId } = useParams();
+    const normalizedUserId = toNumberId(userId);
     const [user, setUser] = useState(null);
     const [rounds, setRounds] = useState([]);
     const [predictions, setPredictions] = useState([]);
+    const [loading, setLoading] = useState(true);
 
     useEffect(() => {
         const loadUser = async () => {
-            const docId = `epl_2025-26_${userId}`; // Добавить из сервиса
-            const docRef = doc(db, "standings", docId);
-            const snapshot = await getDoc(docRef);
+            const standingsQuery = query(
+                collection(db, "standings"),
+                where("leagueId", "==", "epl"),
+                where("userId", "==", normalizedUserId)
+            );
 
-            if (snapshot.exists()) {
-                setUser(snapshot.data());
-            } else {
-                console.warn("Профиль не найден в standings");
+            const snapshot = await getDocs(standingsQuery);
+            if (!snapshot.empty) {
+                setUser(snapshot.docs[0].data());
+                return;
             }
+
+            console.warn("Профиль не найден в standings");
         };
 
         const loadRoundsPoints = async () => {
             const q = query(
                 collection(db, "roundPoints"),
-                where("userId", "==", Number(userId))
+                where("userId", "==", normalizedUserId),
+                where("leagueId", "==", "epl")
             );
 
             const snap = await getDocs(q);
-            const data = snap.docs.map((doc) => {
-              const d = doc.data();
-              return {
-                  round: d.round,
-                  points: d.totalPoints
-              };
-            });
-
-            data.sort((a, b) => a.round - b.round);
-            console.log("Загруженные очки по турам:", data);
-            setRounds(data);
-        };
-
-        const loadPredictions = async () => {
-            const q = query(
-                collection(db, "predictions"),
-                where("userId", "==", Number(userId))
-            );
-
-            const snap = await getDocs(q);
-            const data = snap.docs.map((doc) => {
-                const d = doc.data();
+            const data = snap.docs.map((entry) => {
+                const roundData = entry.data();
                 return {
-                    round: d.round ?? null,
-                    teamA: d.teamA ?? "–",
-                    teamB: d.teamB ?? "–",
-                    scoreA: d.scoreA,
-                    scoreB: d.scoreB,
-                    points: d.points ?? 0
+                    round: roundData.round,
+                    points: roundData.totalPoints ?? 0
                 };
             });
 
             data.sort((a, b) => a.round - b.round);
-            setPredictions(data);
+            setRounds(data);
         };
 
-        loadUser();
-        loadRoundsPoints();
-        loadPredictions();
-    }, [userId]);
+        const loadPredictions = async () => {
+            const predictionsQuery = query(
+                collection(db, "predictions"),
+                where("userId", "==", normalizedUserId)
+            );
 
-    if (!user) return <div>Loading...</div>;
+            const predictionSnap = await getDocs(predictionsQuery);
+            const rawPredictions = predictionSnap.docs.map((entry) => entry.data());
+            const matchIds = [...new Set(rawPredictions.map((prediction) => prediction.matchId).filter(Boolean))];
+
+            let matchesById = {};
+            if (matchIds.length > 0) {
+                const matchChunks = [];
+                for (let i = 0; i < matchIds.length; i += 10) {
+                    matchChunks.push(matchIds.slice(i, i + 10));
+                }
+
+                const matchDocs = await Promise.all(
+                    matchChunks.map((chunk) => getDocs(
+                        query(collection(db, "matches"), where(documentId(), "in", chunk))
+                    ))
+                );
+
+                matchesById = matchDocs.flatMap((chunk) => chunk.docs)
+                    .reduce((acc, matchDoc) => {
+                        acc[matchDoc.id] = matchDoc.data();
+                        return acc;
+                    }, {});
+            }
+
+            const mappedPredictions = rawPredictions.map((prediction) => {
+                const match = matchesById[prediction.matchId] ?? {};
+                return {
+                    matchId: prediction.matchId,
+                    round: match.round ?? null,
+                    teamA: match.teamA ?? "–",
+                    teamB: match.teamB ?? "–",
+                    scoreA: prediction.scoreA,
+                    scoreB: prediction.scoreB,
+                    points: prediction.points ?? 0
+                };
+            });
+
+            mappedPredictions.sort((a, b) => {
+                if ((a.round ?? 0) !== (b.round ?? 0)) {
+                    return (a.round ?? 0) - (b.round ?? 0);
+                }
+                return String(a.matchId).localeCompare(String(b.matchId));
+            });
+
+            setPredictions(mappedPredictions);
+        };
+
+        const load = async () => {
+            setLoading(true);
+            try {
+                await Promise.all([
+                    loadUser(),
+                    loadRoundsPoints(),
+                    loadPredictions()
+                ]);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        load();
+    }, [normalizedUserId]);
+
+    if (loading) return <div>Loading...</div>;
+    if (!user) return <div>Профиль не найден</div>;
 
     return (
         <div className="user-profile-container">
             <div className="user-profile-header">
                 <div>
                     <h2>{user.userName ?? userId}</h2>
-                    <p>Очки: {user.totalPoints}</p>
+                    <p>Очки: {user.totalPoints ?? 0}</p>
                 </div>
             </div>
 
@@ -111,9 +170,9 @@ export default function UserProfile() {
                         </tr>
                     </thead>
                     <tbody>
-                    {predictions.map((item, i) => (
-                        <tr key={i}>
-                            <td>{item.round}</td>
+                    {predictions.map((item) => (
+                        <tr key={item.matchId}>
+                            <td>{item.round ?? "—"}</td>
                             <td>{item.teamA} – {item.teamB}</td>
                             <td>{item.scoreA}:{item.scoreB}</td>
                             <td>{item.points}</td>
@@ -123,5 +182,5 @@ export default function UserProfile() {
                 </table>
             </div>
         </div>
-    )
+    );
 }

--- a/src/hooks/useMatchPredictions.js
+++ b/src/hooks/useMatchPredictions.js
@@ -3,6 +3,14 @@ import {getMatchById, getPredictionsForMatch} from "../services/getPredictionsFo
 import {getUserLeagues} from "./getUserLeagues.js";
 import {calculatePoints} from "../../functions/scoreService.js";
 
+function getLiveResult(matchData) {
+    return {
+        scoreA: matchData?.liveScoreA ?? 0,
+        scoreB: matchData?.liveScoreB ?? 0,
+        firstScorer: matchData?.firstScorer ?? null
+    };
+}
+
 export function useMatchPredictions(matchId, userId) {
     const [match, setMatch] = useState(null);
     const [myPrediction, setMyPrediction] = useState(null);
@@ -18,13 +26,8 @@ export function useMatchPredictions(matchId, userId) {
 
             setMatch(matchData);
             const userPrediction = allPredictions.find(pred => String(pred.userId) === String(userId));
-            if (userPrediction.points === undefined) {
-                userPrediction.points = calculatePoints(userPrediction, {
-                    scoreA: matchData.liveScoreA ?? 0,
-                    scoreB: matchData.liveScoreB ?? 0,
-                    firstScorer: matchData.firstScorer ?? null,
-                    isBoosted: matchData.isBoosted
-                })
+            if (userPrediction && userPrediction.points === undefined) {
+                userPrediction.points = calculatePoints(userPrediction, getLiveResult(matchData));
             }
             setMyPrediction(userPrediction);
 
@@ -35,12 +38,7 @@ export function useMatchPredictions(matchId, userId) {
                         ...prediction,
                         points: matchData?.result
                             ? prediction.points
-                            : calculatePoints(prediction, {
-                                scoreA: matchData.liveScoreA ?? 0,
-                                scoreB: matchData.liveScoreB ?? 0,
-                                firstScorer: matchData.firstScorer ?? null,
-                                isBoosted: matchData.isBoosted
-                            })
+                            : calculatePoints(prediction, getLiveResult(matchData))
                     }))
                     .sort((a, b) => (b.points ?? 0) - (a.points ?? 0))
 

--- a/src/hooks/usePredictions.js
+++ b/src/hooks/usePredictions.js
@@ -30,9 +30,10 @@ export function usePredictions() {
         const hasChanges = Object.keys(updated).some((matchId) => {
             const currentPrediction = updated[matchId];
             const initialPrediction = initialPredictions[matchId] ?? {};
-            return currentPrediction?.scoreA !== initialPrediction.scoreB ||
+            return currentPrediction?.scoreA !== initialPrediction.scoreA ||
                 currentPrediction?.scoreB !== initialPrediction.scoreB ||
-                currentPrediction?.firstScorer !== initialPrediction.firstScorer;
+                currentPrediction?.firstScorer !== initialPrediction.firstScorer ||
+                currentPrediction?.isBoosted !== initialPrediction.isBoosted;
         });
 
         const hasValid = Object.values(updated).some(isValidPrediction);
@@ -56,6 +57,7 @@ export function usePredictions() {
 
         try {
             await firebaseService.savePrediction(userId, userName, currentPredictions);
+            setInitialPredictions(currentPredictions);
             telegramService.showAlert('Прогнозы сохранены ✅');
             telegramService.hideMainButton();
         } catch (err) {

--- a/src/services/telegram.js
+++ b/src/services/telegram.js
@@ -1,8 +1,10 @@
 const tg = window.Telegram?.WebApp;
+const isDevelopment = import.meta.env.DEV;
 
 function getUserId() {
     const telegramUserId = tg?.initDataUnsafe?.user?.id;
     if (telegramUserId) return telegramUserId;
+    if (!isDevelopment) return null;
 
     const fallbackUserId = import.meta.env.VITE_TELEGRAM_USER_ID;
     return fallbackUserId ? Number(fallbackUserId) : null;
@@ -10,9 +12,10 @@ function getUserId() {
 
 function getUserName() {
     const user = tg?.initDataUnsafe?.user;
-    if (!user) {
+    if (!user && isDevelopment) {
         return import.meta.env.VITE_TELEGRAM_USER_NAME || "Unknown";
     }
+    if (!user) return "Unknown";
 
     const firstName = user.first_name || "";
     const lastName = user.last_name || "";

--- a/src/services/telegram.js
+++ b/src/services/telegram.js
@@ -1,13 +1,18 @@
-
-const tg = window.Telegram.WebApp;
+const tg = window.Telegram?.WebApp;
 
 function getUserId() {
-    return tg.initDataUnsafe?.user?.id;
+    const telegramUserId = tg?.initDataUnsafe?.user?.id;
+    if (telegramUserId) return telegramUserId;
+
+    const fallbackUserId = import.meta.env.VITE_TELEGRAM_USER_ID;
+    return fallbackUserId ? Number(fallbackUserId) : null;
 }
 
 function getUserName() {
-    const user = tg.initDataUnsafe?.user;
-    if (!user) return "Unknown";
+    const user = tg?.initDataUnsafe?.user;
+    if (!user) {
+        return import.meta.env.VITE_TELEGRAM_USER_NAME || "Unknown";
+    }
 
     const firstName = user.first_name || "";
     const lastName = user.last_name || "";
@@ -15,28 +20,37 @@ function getUserName() {
 }
 
 function readyWebApp() {
+    if (!tg) return;
     tg.ready();
     tg.expand();
 }
 
 function setMainButton(text = 'Сохранить прогнозы') {
+    if (!tg) return;
     tg.MainButton.setParams({ text });
 }
 
 function showMainButton() {
+    if (!tg) return;
     tg.MainButton.show();
 }
 
 function hideMainButton() {
+    if (!tg) return;
     tg.MainButton.hide();
 }
 
 function setMainButtonClickHandler(handler) {
+    if (!tg) return;
     tg.MainButton.offClick();
     tg.MainButton.onClick(handler);
 }
 
 function showAlert(message) {
+    if (!tg) {
+        window.alert(message);
+        return;
+    }
     tg.showAlert(message);
 }
 


### PR DESCRIPTION
## What changed

This PR fixes a set of review findings in the predictions flow and user profile flow.

- fixed Telegram WebApp identity handling so the frontend no longer depends on a hardcoded user id
- fixed prediction dirty-state detection so score changes and boost changes correctly show the save button
- fixed match prediction details so the page no longer crashes when the current user has no prediction yet
- fixed live standings match-start detection for Firestore timestamps
- fixed reminder link generation so the match deep link uses the actual `matchId`
- rebuilt the user profile screen around the current Firestore schema instead of stale hardcoded document assumptions

## Why

The current implementation had a few real runtime issues:

- one hardcoded Telegram user id could make reads and writes happen under the wrong account
- the save button logic compared `scoreA` against the previous `scoreB`, which made change detection unreliable
- the profile page expected fields that no longer exist in `predictions`
- the reminder URL used a plain string instead of a template literal
- live standings compared Firestore timestamp objects directly to `Date.now()`

## Impact

Users should now see the correct Telegram identity, get a more reliable save flow, avoid crashes on the match predictions page, and see a profile page that matches the current data model.

## Validation

- reviewed the affected flows and verified the diff locally
- local build validation was not available in this environment because `npm` is not installed
- direct `git push` was not available because the local GitHub HTTPS auth was missing, so the branch was published through the GitHub connector instead
